### PR TITLE
experimental open-line function

### DIFF
--- a/api/src/scala/scaled/major/EditingMode.scala
+++ b/api/src/scala/scaled/major/EditingMode.scala
@@ -40,7 +40,8 @@ abstract class EditingMode (env :Env) extends ReadingMode(env) {
 
     bind("newline",                "ENTER", "S-ENTER").
     bind("indent-for-tab-command", "TAB").
-    // TODO: open-line, split-line, ...
+    bind("open-line", "C-o").
+    // TODO: split-line, ...
 
     bind("indent-rigidly",   "M-RIGHT").
     bind("unindent-rigidly", "M-LEFT").
@@ -258,6 +259,13 @@ abstract class EditingMode (env :Env) extends ReadingMode(env) {
          Characters after the point on the current line wil be moved to a new line.""")
   def newline () {
     buffer.split(view.point())
+  }
+
+  @Fn("""Opens a line above the current line.""")
+  def openLine() {
+    val was = view.point()
+    newline()
+    view.point() = was
   }
 
   @Fn("Indents the current line or region, or inserts a tab, as appropriate.")


### PR DESCRIPTION
My attempt in this simple PR was to add a command which mimics the behaviour of the `C-o` command in Emacs:

![Peek 2019-03-14 11-29](https://user-images.githubusercontent.com/2242307/54353944-3e1c9f00-464d-11e9-9c58-057407c0d657.gif)

Maybe we should delete whitespace at the beginning of the new lines?